### PR TITLE
Add CA certificates for SSL communication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,9 @@ build_initrd:
 	cd ${RAMDISK_DIR}/lib/python3.10/site-packages/${PYTHON_PKG_NAME}/ && \
 		find . -name '*.py[co]' -delete && \
 		find . -name __pycache__ -type d -exec rm -rf {} +
-
+# Add CA certificates
+	mkdir -p ${RAMDISK_DIR}/etc/ssl/certs
+	cp /etc/ssl/certs/ca-certificates.crt ${RAMDISK_DIR}/etc/ssl/certs/
 # Build initramfs
 	cd ${RAMDISK_DIR} && \
 		find . | cpio -H newc -o | gzip -9 >../${RAMDISK_NAME}

--- a/init
+++ b/init
@@ -25,7 +25,7 @@ export PYTHONHOME=/
 export PYTHON_VER="3.10"
 export PYTHONPATH="$PYTHONPATH:/lib/:/lib/python$PYTHON_VER/site-packages/genesis_seed"
 export SEED_OS_AGENT="/lib/python$PYTHON_VER/site-packages/genesis_seed/genesis_seed/cmd/agent.py"
-
+export SSL_CERT_FILE="/etc/ssl/certs/ca-certificates.crt"
 
 # Check available interfaces and bring them up
 for iface_path in /sys/class/net/eth*; do


### PR DESCRIPTION
CA certificates allow to establish correct HTTPS connections and use images from repositories on HTTPS servers.