### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
 #      - name: Install deps
 #        run: sudo apt install --yes liblzma-dev bison flex libelf-dev libssl-dev
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 30
       - name: Build binaries(Kernel, Busybox, Python, Initrd) on Self-Hosted runner

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         python-version: ["3.12"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
@@ -30,7 +30,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
## Summary

Consolidates Dependabot PR #32 (`actions/checkout` v6 → v7).

## Validation

Validated exact commit `fe30f969cab35ddd262696f7887730d8593b7baa`:

- the complete self-hosted build path passes, including kernel, BusyBox, Python, initrd, and iPXE;
- lint passes on Python 3.12;
- tests pass on Python 3.10–3.14;
- the branch contains only the intended workflow dependency update.

A detailed upstream review is available in the PR discussion.

**Decision: safe to merge and ready for review.**
